### PR TITLE
change deprecated state_publisher to robot_state_publisher

### DIFF
--- a/youbot_drivers/youbot_oodl/launch/youbot_joint_state_publisher.launch
+++ b/youbot_drivers/youbot_oodl/launch/youbot_joint_state_publisher.launch
@@ -6,7 +6,7 @@
 		<!-- remap from="joint_states" to="youbot_state"/> -->
 	
 	<!-- start robot_state_publisher assuming /joint_states is the default topic -->
-	<node pkg="robot_state_publisher" type="state_publisher" name="robot_state_publisher" output="screen"/>
+	<node pkg="robot_state_publisher" type="joint_state_publisher" name="robot_state_publisher" output="screen"/>
 	
 	<!-- start robot_state_publisher assuming /joint_states is not the default topic and the drivers default topics are used -->
 	<!--


### PR DESCRIPTION
 The 'state_publisher' executable is deprecated. Use 'robot_state_publisher' instead
![screenshot from 2015-11-25 09 43 21](https://cloud.githubusercontent.com/assets/7522853/11386057/0478d7d2-9359-11e5-8179-138542cc1001.png)
